### PR TITLE
Add state changes callbacks to props and pageSize initial state prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chakra-ui-table-v2",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "React component for Data Table using Chakra UI and Tanstack Table V.8",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chakra-ui-table-v2",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "React component for Data Table using Chakra UI and Tanstack Table V.8",
   "keywords": [
     "react",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,7 @@ const TodoListTable = () => {
     }),
     columnHelper.accessor("bodySize", {
       cell: (info) => info.getValue()?.height,
+      enableColumnFilter: false,
       header: "Body Size",
     }),
   ];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,11 @@ type TodoItem = {
   date: Date;
   hairColor: HairColor;
   foods: string[];
+  bodySize: {
+    height: number;
+    waist: number;
+    shoulders: number;
+  };
 };
 
 enum HairColor {
@@ -71,6 +76,10 @@ const TodoListTable = () => {
       header: "Eats",
       filterFn: arrayFilterFn,
     }),
+    columnHelper.accessor("bodySize", {
+      cell: (info) => info.getValue()?.height,
+      header: "Body Size",
+    }),
   ];
 
   const [data, setData] = useState(null);
@@ -87,6 +96,18 @@ const TodoListTable = () => {
       );
 
       const foods = ["meat", "vegan", "lactose"];
+
+      const bodySize = {
+        height: 180,
+        waist: 120,
+        shoulders: 140,
+      };
+      const bodySizeWithDefault = {
+        height: 180,
+        waist: 120,
+        shoulders: 140,
+        default: 222,
+      };
 
       if (result.length === 2) {
         // index 0 is user
@@ -109,17 +130,20 @@ const TodoListTable = () => {
             case 0:
               todo.hairColor = HairColor.BLONDE;
               todo.foods = foods.slice(0, 1);
+              todo.bodySize = bodySize;
 
               break;
 
             case 1:
               todo.hairColor = HairColor.BROWN;
               todo.foods = foods.slice(0, 2);
+              todo.bodySize = bodySizeWithDefault;
               break;
 
             case 2:
               todo.hairColor = HairColor.RED;
               todo.foods = foods.slice(0, 3);
+              todo.bodySize = null;
               break;
 
             default:

--- a/src/lib/components/DataTable.tsx
+++ b/src/lib/components/DataTable.tsx
@@ -137,6 +137,10 @@ export type DataTableProps<Data extends object> = {
   initialColumnFilters?: ColumnFiltersState;
   initialPageSize?: PageSize;
   filterIsOpen?: boolean;
+  onChangePageSize?: (newPageSize: PageSize) => void;
+  onSortingChange?: (filters: SortingState) => void;
+  onColumnVisibilityChange?: (filters: VisibilityState) => void;
+  onColumnFiltersChange?: (filters: ColumnFiltersState) => void;
 };
 
 export function DataTable<Data extends object>({
@@ -150,6 +154,10 @@ export function DataTable<Data extends object>({
   initialColumnFilters = [],
   initialPageSize = DEFAULT_PAGES[1],
   filterIsOpen = false,
+  onChangePageSize = () => {},
+  onSortingChange,
+  onColumnVisibilityChange,
+  onColumnFiltersChange,
 }: DataTableProps<Data>) {
   const [sorting, setSorting] = useState<SortingState>(initialSortingState);
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(
@@ -172,16 +180,37 @@ export function DataTable<Data extends object>({
       columnFilters,
     },
     getCoreRowModel: getCoreRowModel(),
-    // sorting
-    onSortingChange: setSorting,
+    onSortingChange: (newFilters) => {
+      setSorting(newFilters);
+      const updatedFilters =
+        typeof newFilters === "function" ? newFilters(sorting) : newFilters;
+      if (onSortingChange) {
+        onSortingChange(updatedFilters);
+      }
+    },
     getSortedRowModel: getSortedRowModel(),
-    // pagination
     getPaginationRowModel: getPaginationRowModel(),
-    // column visible
-    onColumnVisibilityChange: setColumnVisibility,
-    // column filter
+    onColumnVisibilityChange: (newFilters) => {
+      setColumnVisibility(newFilters);
+      const updatedFilters =
+        typeof newFilters === "function"
+          ? newFilters(columnVisibility)
+          : newFilters;
+      if (onColumnVisibilityChange) {
+        onColumnVisibilityChange(updatedFilters);
+      }
+    },
     getFilteredRowModel: getFilteredRowModel(),
-    onColumnFiltersChange: setColumnFilters,
+    onColumnFiltersChange: (newFilters) => {
+      setColumnFilters(newFilters);
+      const updatedFilters =
+        typeof newFilters === "function"
+          ? newFilters(columnFilters)
+          : newFilters;
+      if (onColumnFiltersChange) {
+        onColumnFiltersChange(updatedFilters);
+      }
+    },
     getFacetedRowModel: getFacetedRowModel(),
     getFacetedUniqueValues: getFacetedUniqueValues(),
     getFacetedMinMaxValues: getFacetedMinMaxValues(),
@@ -445,6 +474,7 @@ export function DataTable<Data extends object>({
                       size="sm"
                       onChange={(e) => {
                         table.setPageSize(Number(e.target.value));
+                        onChangePageSize(Number(e.target.value) as PageSize);
                       }}
                     >
                       {DEFAULT_PAGES.map((pageSize, index) => (

--- a/src/lib/components/DataTable.tsx
+++ b/src/lib/components/DataTable.tsx
@@ -135,7 +135,7 @@ export type DataTableProps<Data extends object> = {
   initialSortingState?: SortingState;
   initialColumnVisibility?: VisibilityState;
   initialColumnFilters?: ColumnFiltersState;
-  initialPageSize: PageSize;
+  initialPageSize?: PageSize;
   filterIsOpen?: boolean;
 };
 

--- a/src/lib/components/DataTable.tsx
+++ b/src/lib/components/DataTable.tsx
@@ -278,60 +278,69 @@ export function DataTable<Data extends object>({
                                 ))}
                             </Box>
                           </HStack>
-                          <Box w="1rem" display="flex" justifyContent="center">
-                            {filterDisclosure.isOpen && (
-                              <Menu closeOnSelect={false}>
-                                <MenuButton
-                                  as={IconButton}
-                                  icon={
-                                    header.column.getFilterValue() ===
-                                    undefined ? (
-                                      <SearchIcon />
-                                    ) : (
-                                      <Search2Icon />
-                                    )
-                                  }
-                                  isRound={true}
-                                  variant="ghost"
-                                  colorScheme={
-                                    header.column.getFilterValue() === undefined
-                                      ? "gray"
-                                      : "orange"
-                                  }
-                                  fontSize="1rem"
-                                  aria-label="column filter"
-                                  size="sm"
-                                />
-                                <MenuList p="0.5rem">
-                                  <Flex
-                                    w="full"
-                                    direction="column"
-                                    gap="0.5rem"
-                                  >
-                                    {header.column.getCanFilter() && (
-                                      <Flex>
-                                        <Filter
-                                          column={header.column}
-                                          table={table}
-                                        />
-                                      </Flex>
-                                    )}
-                                    <Button
-                                      rightIcon={<FaTrash />}
-                                      colorScheme="blue"
-                                      variant="ghost"
-                                      size="sm"
-                                      onClick={() =>
-                                        header.column.setFilterValue(undefined)
-                                      }
+                          {!header.column.getCanFilter() ? null : (
+                            <Box
+                              w="1rem"
+                              display="flex"
+                              justifyContent="center"
+                            >
+                              {filterDisclosure.isOpen && (
+                                <Menu closeOnSelect={false}>
+                                  <MenuButton
+                                    as={IconButton}
+                                    icon={
+                                      header.column.getFilterValue() ===
+                                      undefined ? (
+                                        <SearchIcon />
+                                      ) : (
+                                        <Search2Icon />
+                                      )
+                                    }
+                                    isRound={true}
+                                    variant="ghost"
+                                    colorScheme={
+                                      header.column.getFilterValue() ===
+                                      undefined
+                                        ? "gray"
+                                        : "orange"
+                                    }
+                                    fontSize="1rem"
+                                    aria-label="column filter"
+                                    size="sm"
+                                  />
+                                  <MenuList p="0.5rem">
+                                    <Flex
+                                      w="full"
+                                      direction="column"
+                                      gap="0.5rem"
                                     >
-                                      Reset
-                                    </Button>
-                                  </Flex>
-                                </MenuList>
-                              </Menu>
-                            )}
-                          </Box>
+                                      {header.column.getCanFilter() && (
+                                        <Flex>
+                                          <Filter
+                                            column={header.column}
+                                            table={table}
+                                          />
+                                        </Flex>
+                                      )}
+                                      <Button
+                                        rightIcon={<FaTrash />}
+                                        colorScheme="blue"
+                                        variant="ghost"
+                                        size="sm"
+                                        onClick={() =>
+                                          header.column.setFilterValue(
+                                            undefined
+                                          )
+                                        }
+                                      >
+                                        Reset
+                                      </Button>
+                                    </Flex>
+                                  </MenuList>
+                                </Menu>
+                              )}
+                            </Box>
+                          )}
                         </Flex>
                       </Th>
                     );

--- a/src/lib/components/DataTable.tsx
+++ b/src/lib/components/DataTable.tsx
@@ -70,7 +70,8 @@ import { Dispatch, SetStateAction, useMemo, useState } from "react";
 import { getNumformat } from "../utils/formatters";
 import { SingleDatepicker } from "chakra-dayzed-datepicker";
 
-export const DEFAULT_PAGES = [20, 50, 100];
+export const DEFAULT_PAGES = [10, 20, 50, 100] as const;
+export type PageSize = (typeof DEFAULT_PAGES)[number];
 
 export const NoDataDisplay = () => {
   return (
@@ -134,6 +135,7 @@ export type DataTableProps<Data extends object> = {
   initialSortingState?: SortingState;
   initialColumnVisibility?: VisibilityState;
   initialColumnFilters?: ColumnFiltersState;
+  initialPageSize: PageSize;
   filterIsOpen?: boolean;
 };
 
@@ -146,6 +148,7 @@ export function DataTable<Data extends object>({
   initialSortingState = [],
   initialColumnVisibility = {},
   initialColumnFilters = [],
+  initialPageSize = DEFAULT_PAGES[1],
   filterIsOpen = false,
 }: DataTableProps<Data>) {
   const [sorting, setSorting] = useState<SortingState>(initialSortingState);
@@ -161,7 +164,7 @@ export function DataTable<Data extends object>({
   const table = useReactTable({
     columns,
     data: data || [],
-    initialState: { pagination: { pageSize: DEFAULT_PAGES[0] } },
+    initialState: { pagination: { pageSize: initialPageSize } },
     autoResetPageIndex: false,
     state: {
       sorting,

--- a/src/lib/components/DataTable.tsx
+++ b/src/lib/components/DataTable.tsx
@@ -530,6 +530,11 @@ function TableController<Data extends object>({
         if (value instanceof Date) {
           // Check if the value is a Date object
           originalRow[key] = value.toLocaleString(); // Convert the date to a locale string
+        } else if (value instanceof Object) {
+          // Check if the value is an object, if so use the property "default" or the first one
+          originalRow[key] = value.hasOwnProperty("default")
+            ? value["default"]
+            : Object.values(value)[0];
         }
       });
       return originalRow;


### PR DESCRIPTION
This allows the implementation to get the state of the table, allowing for example to store this state in the app side to then launch instances of this table with the same predefined state (eg. user preferences)